### PR TITLE
AnyState Events and Transitions

### DIFF
--- a/Packages/com.nickmaltbie.StateMachineUnity/Scripts/Attributes/AnimationTransitionAttribute.cs
+++ b/Packages/com.nickmaltbie.StateMachineUnity/Scripts/Attributes/AnimationTransitionAttribute.cs
@@ -63,9 +63,9 @@ namespace nickmaltbie.StateMachineUnity.Attributes
         }
 
         /// <inheritdoc/>
-        public override void OnTransition<E>(IStateMachine<E> sm)
+        public override void OnTransition(IStateMachine<Type> sm)
         {
-            var animStateMachine = sm as IAnimStateMachine<E>;
+            var animStateMachine = sm as IAnimStateMachine<Type>;
             int? nextState = AnimationAttribute.GetStateAnimation(TargetState);
             if (nextState.HasValue)
             {

--- a/Packages/com.nickmaltbie.StateMachineUnity/Scripts/Attributes/TransitionFromAnyState.cs
+++ b/Packages/com.nickmaltbie.StateMachineUnity/Scripts/Attributes/TransitionFromAnyState.cs
@@ -17,41 +17,19 @@
 // SOFTWARE.
 
 using System;
-using nickmaltbie.StateMachineUnity.Attributes;
 
-namespace nickmaltbie.StateMachineUnity
+namespace nickmaltbie.StateMachineUnity.Attributes
 {
     /// <summary>
-    /// Basic state to represent the current configuration of a state machine.
+    /// Transition to this state from any other state given an event.
     /// </summary>
-    public abstract class State
+    [AttributeUsage(AttributeTargets.Class, AllowMultiple = true, Inherited = false)]
+    public class TransitionFromAnyState : TransitionAttribute
     {
         /// <summary>
-        /// Checks if a given state is labeled with the initial state type.
+        /// Transition to this state from any other state given an event.
         /// </summary>
-        /// <param name="type">Type of state to check.</param>
-        /// <returns>True if this is the initial state, flase otherwise.</returns>
-        public static bool IsInitialState(Type type)
-        {
-            return Attribute.GetCustomAttribute(type, typeof(InitialStateAttribute)) != null;
-        }
-    }
-
-    /// <summary>
-    /// State that represents a transition from any state to
-    /// a given state.
-    /// </summary>
-    public class FromAnyState : State
-    {
-
-    }
-
-    /// <summary>
-    /// Static class to represent a transition
-    /// from any state to a given state. 
-    /// /// </summary>
-    public class AnyState : State
-    {
-
+        /// <param name="triggerEvent">Trigger event to cause transition.</param>
+        public TransitionFromAnyState(Type triggerEvent) : base(triggerEvent, typeof(FromAnyState)) { }
     }
 }

--- a/Packages/com.nickmaltbie.StateMachineUnity/Scripts/Attributes/TransitionFromAnyState.cs.meta
+++ b/Packages/com.nickmaltbie.StateMachineUnity/Scripts/Attributes/TransitionFromAnyState.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3656847774f2ea543bf8e9a08e36a15e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.nickmaltbie.StateMachineUnity/Scripts/Attributes/TransitionFromAnyStateAttribute.cs
+++ b/Packages/com.nickmaltbie.StateMachineUnity/Scripts/Attributes/TransitionFromAnyStateAttribute.cs
@@ -17,32 +17,19 @@
 // SOFTWARE.
 
 using System;
-using nickmaltbie.StateMachineUnity.Attributes;
 
-namespace nickmaltbie.StateMachineUnity
+namespace nickmaltbie.StateMachineUnity.Attributes
 {
     /// <summary>
-    /// Basic state to represent the current configuration of a state machine.
+    /// Transition to this state from any other state given an event.
     /// </summary>
-    public abstract class State
+    [AttributeUsage(AttributeTargets.Class, AllowMultiple = true, Inherited = false)]
+    public class TransitionFromAnyStateAttribute : TransitionFromAttribute
     {
         /// <summary>
-        /// Checks if a given state is labeled with the initial state type.
+        /// Transition to this state from any other state given an event.
         /// </summary>
-        /// <param name="type">Type of state to check.</param>
-        /// <returns>True if this is the initial state, flase otherwise.</returns>
-        public static bool IsInitialState(Type type)
-        {
-            return Attribute.GetCustomAttribute(type, typeof(InitialStateAttribute)) != null;
-        }
-    }
-
-    /// <summary>
-    /// Static class to represent a transition
-    /// from any state to a given state. 
-    /// /// </summary>
-    public class AnyState : State
-    {
-
+        /// <param name="triggerEvent">Trigger event to cause transition.</param>
+        public TransitionFromAnyStateAttribute(Type triggerEvent) : base(triggerEvent, typeof(AnyState)) { }
     }
 }

--- a/Packages/com.nickmaltbie.StateMachineUnity/Scripts/Attributes/TransitionFromAnyStateAttribute.cs.meta
+++ b/Packages/com.nickmaltbie.StateMachineUnity/Scripts/Attributes/TransitionFromAnyStateAttribute.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 3656847774f2ea543bf8e9a08e36a15e
+guid: 5400d92da2864314487c94127191a917
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/Packages/com.nickmaltbie.StateMachineUnity/Scripts/Attributes/TransitionFromAttribute.cs
+++ b/Packages/com.nickmaltbie.StateMachineUnity/Scripts/Attributes/TransitionFromAttribute.cs
@@ -17,32 +17,20 @@
 // SOFTWARE.
 
 using System;
-using nickmaltbie.StateMachineUnity.Attributes;
 
-namespace nickmaltbie.StateMachineUnity
+namespace nickmaltbie.StateMachineUnity.Attributes
 {
     /// <summary>
-    /// Basic state to represent the current configuration of a state machine.
+    /// Transition attribute to manage transitions between states for a state machine.
     /// </summary>
-    public abstract class State
+    [AttributeUsage(AttributeTargets.Class, AllowMultiple = true, Inherited = false)]
+    public class TransitionFromAttribute : TransitionAttribute
     {
         /// <summary>
-        /// Checks if a given state is labeled with the initial state type.
+        /// Transition from a given state to another state.
         /// </summary>
-        /// <param name="type">Type of state to check.</param>
-        /// <returns>True if this is the initial state, flase otherwise.</returns>
-        public static bool IsInitialState(Type type)
-        {
-            return Attribute.GetCustomAttribute(type, typeof(InitialStateAttribute)) != null;
-        }
-    }
-
-    /// <summary>
-    /// Static class to represent a transition
-    /// from any state to a given state. 
-    /// /// </summary>
-    public class AnyState : State
-    {
-
+        /// <param name="triggerEvent">Trigger event to cause transition.</param>
+        /// <param name="fromState">New state to transition to upon trigger.</param>
+        public TransitionFromAttribute(Type triggerEvent, Type fromState) : base(triggerEvent, fromState) { }
     }
 }

--- a/Packages/com.nickmaltbie.StateMachineUnity/Scripts/Attributes/TransitionFromAttribute.cs.meta
+++ b/Packages/com.nickmaltbie.StateMachineUnity/Scripts/Attributes/TransitionFromAttribute.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ac2ca3ced68d2ec40937708e050bc0da
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.nickmaltbie.StateMachineUnity/Scripts/Attributes/TransitionWrapper.cs
+++ b/Packages/com.nickmaltbie.StateMachineUnity/Scripts/Attributes/TransitionWrapper.cs
@@ -39,8 +39,8 @@ namespace nickmaltbie.StateMachineUnity.Attributes
         /// <param name="transitionBase">Transition base to trigger OnTransition event from.</param>
         public TransitionWrapper(Type triggerEvent, E targetState, ITransition<E> transitionBase)
         {
-            this.TriggerEvent = triggerEvent;
-            this.TargetState = targetState;
+            TriggerEvent = triggerEvent;
+            TargetState = targetState;
             this.transitionBase = transitionBase;
         }
 

--- a/Packages/com.nickmaltbie.StateMachineUnity/Scripts/Attributes/TransitionWrapper.cs
+++ b/Packages/com.nickmaltbie.StateMachineUnity/Scripts/Attributes/TransitionWrapper.cs
@@ -21,36 +21,37 @@ using System;
 namespace nickmaltbie.StateMachineUnity.Attributes
 {
     /// <summary>
-    /// Transition attribute to manage transitions between states for a state machine.
+    /// Transition wrapper for creating reversed transitions.
     /// </summary>
-    [AttributeUsage(AttributeTargets.Class, AllowMultiple = true, Inherited = false)]
-    public class TransitionAttribute : Attribute, ITransition<Type>
+    public class TransitionWrapper<E> : ITransition<E>
     {
-        /// <summary>
-        /// Type of event to listen for.
-        /// </summary>
         public Type TriggerEvent { get; private set; }
 
-        /// <summary>
-        /// Target state upon event trigger.
-        /// </summary>
-        public Type TargetState { get; private set; }
+        public E TargetState { get; private set; }
+
+        private ITransition<E> transitionBase;
 
         /// <summary>
         /// Transition to another state on a given event.
         /// </summary>
         /// <param name="triggerEvent">Trigger event to cause transition.</param>
         /// <param name="targetState">New state to transition to upon trigger.</param>
-        public TransitionAttribute(Type triggerEvent, Type targetState)
+        /// <param name="transitionBase">Transition base to trigger OnTransition event from.</param>
+        public TransitionWrapper(Type triggerEvent, E targetState, ITransition<E> transitionBase)
         {
-            TriggerEvent = triggerEvent;
-            TargetState = targetState;
+            this.TriggerEvent = triggerEvent;
+            this.TargetState = targetState;
+            this.transitionBase = transitionBase;
         }
 
         /// <summary>
         /// Behaviour to invoke when this transition is triggered.
         /// </summary>
         /// <param name="sm">State machine being transitioned.</param>
-        public virtual void OnTransition(IStateMachine<Type> sm) { }
+        /// <typeparam name="E">Type of the state machine.</typeparam>
+        public void OnTransition(IStateMachine<E> sm)
+        {
+            transitionBase.OnTransition(sm);
+        }
     }
 }

--- a/Packages/com.nickmaltbie.StateMachineUnity/Scripts/Attributes/TransitionWrapper.cs.meta
+++ b/Packages/com.nickmaltbie.StateMachineUnity/Scripts/Attributes/TransitionWrapper.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 10830c0e2d6587c4083e3701ad403298
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.nickmaltbie.StateMachineUnity/Scripts/ITransition.cs
+++ b/Packages/com.nickmaltbie.StateMachineUnity/Scripts/ITransition.cs
@@ -17,19 +17,30 @@
 // SOFTWARE.
 
 using System;
+using nickmaltbie.StateMachineUnity.Attributes;
 
-namespace nickmaltbie.StateMachineUnity.Attributes
+namespace nickmaltbie.StateMachineUnity
 {
     /// <summary>
-    /// Transition to this state from any other state given an event.
+    /// Transition that can be triggered by an event.
     /// </summary>
-    [AttributeUsage(AttributeTargets.Class, AllowMultiple = true, Inherited = false)]
-    public class TransitionFromAnyState : TransitionAttribute
+    /// <typeparam name="TState">Type of the state machine.</typeparam>
+    public interface ITransition<TState>
     {
         /// <summary>
-        /// Transition to this state from any other state given an event.
+        /// Type of event to listen for.
         /// </summary>
-        /// <param name="triggerEvent">Trigger event to cause transition.</param>
-        public TransitionFromAnyState(Type triggerEvent) : base(triggerEvent, typeof(FromAnyState)) { }
+        public Type TriggerEvent { get; }
+
+        /// <summary>
+        /// Target state upon event trigger.
+        /// </summary>
+        public TState TargetState { get; }
+
+        /// <summary>
+        /// Behaviour to invoke when this transition is triggered.
+        /// </summary>
+        /// <param name="sm">State machine being transitioned.</param>
+        public void OnTransition(IStateMachine<TState> sm);
     }
 }

--- a/Packages/com.nickmaltbie.StateMachineUnity/Scripts/ITransition.cs
+++ b/Packages/com.nickmaltbie.StateMachineUnity/Scripts/ITransition.cs
@@ -17,7 +17,6 @@
 // SOFTWARE.
 
 using System;
-using nickmaltbie.StateMachineUnity.Attributes;
 
 namespace nickmaltbie.StateMachineUnity
 {

--- a/Packages/com.nickmaltbie.StateMachineUnity/Scripts/ITransition.cs.meta
+++ b/Packages/com.nickmaltbie.StateMachineUnity/Scripts/ITransition.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ae82f555a1fe6d94bae196ba2a70841e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.nickmaltbie.StateMachineUnity/Scripts/Utils/FSMUtils.cs
+++ b/Packages/com.nickmaltbie.StateMachineUnity/Scripts/Utils/FSMUtils.cs
@@ -95,7 +95,7 @@ namespace nickmaltbie.StateMachineUnity.Utils
                     {
                         targetState = typeof(AnyState);
                     }
-                    
+
                     actionLookup[new Tuple<Type, Type>(targetState, actionType)] = GetActionWithName(stateMachine, attr.Action);
                 }
             }

--- a/Packages/com.nickmaltbie.StateMachineUnity/Tests/EditMode/Fixed/StateMachineAnyStateTests.cs
+++ b/Packages/com.nickmaltbie.StateMachineUnity/Tests/EditMode/Fixed/StateMachineAnyStateTests.cs
@@ -91,7 +91,7 @@ namespace nickmaltbie.StateMachineUnity.Tests.EditMode.Fixed
     [TestFixture]
     public class StateMachineAnyStateTests : TestBase
     {
-        AnyStateTransitionDemo demo;
+        private AnyStateTransitionDemo demo;
 
         [SetUp]
         public override void Setup()

--- a/Packages/com.nickmaltbie.StateMachineUnity/Tests/EditMode/Fixed/StateMachineAnyStateTests.cs
+++ b/Packages/com.nickmaltbie.StateMachineUnity/Tests/EditMode/Fixed/StateMachineAnyStateTests.cs
@@ -1,0 +1,196 @@
+// Copyright (C) 2022 Nicholas Maltbie
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+// associated documentation files (the "Software"), to deal in the Software without restriction,
+// including without limitation the rights to use, copy, modify, merge, publish, distribute,
+// sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all copies or
+// substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+// BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+// CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+// ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using nickmaltbie.StateMachineUnity.Attributes;
+using nickmaltbie.StateMachineUnity.Event;
+using nickmaltbie.StateMachineUnity.Fixed;
+using nickmaltbie.StateMachineUnity.Tests.EditMode.Event;
+using nickmaltbie.StateMachineUnity.Utils;
+using nickmaltbie.TestUtilsUnity.Tests.TestCommon;
+using NUnit.Framework;
+using static nickmaltbie.StateMachineUnity.Tests.EditMode.Fixed.AnyStateTransitionDemo;
+
+namespace nickmaltbie.StateMachineUnity.Tests.EditMode.Fixed
+{
+    public class PreemptEvent : IEvent
+    {
+
+    }
+
+    public class AnyStateTransitionDemo : FixedSM
+    {
+        public ConcurrentDictionary<Type, int> EntryCount { get; private set; } = new ConcurrentDictionary<Type, int>();
+        public ConcurrentDictionary<Type, int> ExitCount { get; private set; } = new ConcurrentDictionary<Type, int>();
+        public ConcurrentDictionary<Type, int> StateCounter { get; private set; } = new ConcurrentDictionary<Type, int>();
+        public int counter = 0;
+
+        [InitialState]
+        [Transition(typeof(DEvent1), typeof(StateD))]
+        public class StateA : State { }
+
+        [OnEventDoAction(typeof(TestEvent), nameof(IncrementStateCounter))]
+        public class StateB : State { }
+
+        [TransitionFromAnyState(typeof(CEvent))]
+        [OnEventDoAction(typeof(TestEvent), nameof(IncrementStateCounter))]
+        public class StateC : State { }
+
+        [TransitionFrom(typeof(DEvent2), typeof(StateA))]
+        public class StateD : State { }
+
+        [Transition(typeof(PreemptEvent), typeof(StateA))]
+        public class PreemptState : State { }
+
+        [Transition(typeof(AEvent), typeof(StateA))]
+        [Transition(typeof(BEvent), typeof(StateB))]
+        [Transition(typeof(PreemptEvent), typeof(PreemptState))]
+        [OnEventDoAction(typeof(TestEvent), nameof(IncrementCounter))]
+        [OnEnterState(nameof(OnEnterState))]
+        [OnExitState(nameof(OnExitState))]
+        public class Any : AnyState { }
+
+        public void IncrementCounter()
+        {
+            counter++;
+        }
+
+        public void IncrementStateCounter()
+        {
+            StateCounter.AddOrUpdate(CurrentState, 1, (_, v) => v + 1);
+        }
+
+        public void OnEnterState()
+        {
+            EntryCount.AddOrUpdate(CurrentState, 1, (_, v) => v + 1);
+        }
+
+        public void OnExitState()
+        {
+            ExitCount.AddOrUpdate(CurrentState, 1, (_, v) => v + 1);
+        }
+    }
+
+    [TestFixture]
+    public class StateMachineAnyStateTests : TestBase
+    {
+        AnyStateTransitionDemo demo;
+
+        [SetUp]
+        public override void Setup()
+        {
+            base.Setup();
+
+            demo = new AnyStateTransitionDemo();
+        }
+
+        [Test]
+        public void VerifyAnyStateTransitions()
+        {
+            StateMachineTestUtils.SendAndVerifyEventSequence(
+                demo,
+                (new DEvent1(), typeof(StateD)),
+                (new AEvent(), typeof(StateA)),
+                (new BEvent(), typeof(StateB)),
+                (new CEvent(), typeof(StateC)),
+                (new DEvent1(), typeof(StateC)),
+                (new AEvent(), typeof(StateA)),
+                (new DEvent1(), typeof(StateD)),
+                (new DEvent2(), typeof(StateD)),
+                (new BEvent(), typeof(StateB)),
+                (new DEvent2(), typeof(StateB)));
+        }
+
+        [Test]
+        public void VerifyAnyStateTransitionCounts()
+        {
+            StateMachineTestUtils.SendAndVerifyEventSequence(demo, (new AEvent(), typeof(StateA)));
+            Assert.IsTrue(demo.EntryCount.TryGetValue(typeof(StateA), out int aEntryCount));
+            Assert.IsTrue(demo.ExitCount.TryGetValue(typeof(StateA), out int aExitCount));
+            Assert.AreEqual(2, aEntryCount);
+            Assert.AreEqual(1, aExitCount);
+
+            StateMachineTestUtils.SendAndVerifyEventSequence(demo, (new BEvent(), typeof(StateB)));
+            Assert.IsTrue(demo.EntryCount.TryGetValue(typeof(StateA), out aEntryCount));
+            Assert.IsTrue(demo.ExitCount.TryGetValue(typeof(StateA), out aExitCount));
+            Assert.IsTrue(demo.EntryCount.TryGetValue(typeof(StateB), out int bEntryCount));
+            Assert.IsFalse(demo.ExitCount.TryGetValue(typeof(StateB), out int _));
+            Assert.AreEqual(2, aEntryCount);
+            Assert.AreEqual(2, aExitCount);
+            Assert.AreEqual(1, bEntryCount);
+        }
+
+        [Test]
+        public void VerifyAnyStatePreemptEvents()
+        {
+            StateMachineTestUtils.SendAndVerifyEventSequence(demo,
+                (new AEvent(), typeof(StateA)),
+                (new PreemptEvent(), typeof(PreemptState)),
+                (new PreemptEvent(), typeof(StateA)),
+                (new PreemptEvent(), typeof(PreemptState)),
+                (new PreemptEvent(), typeof(StateA)),
+                (new PreemptEvent(), typeof(PreemptState)),
+                (new PreemptEvent(), typeof(StateA)),
+                (new PreemptEvent(), typeof(PreemptState)),
+                (new PreemptEvent(), typeof(StateA)),
+                (new PreemptEvent(), typeof(PreemptState)),
+                (new PreemptEvent(), typeof(StateA)));
+        }
+
+        [Test]
+        public void VerifyInvalidTransitionThrowsException()
+        {
+            ITransition<Type> invalidTransitionTo = new TransitionAttribute(typeof(AEvent), typeof(AnyState));
+            ITransition<Type> invalidTransitionFrom = new TransitionFromAttribute(typeof(AEvent), typeof(StateA));
+            Dictionary<Tuple<Type, Type>, ITransition<Type>> lookup = new();
+
+            Assert.Throws<InvalidOperationException>(() => FSMUtils.SetupTransition(typeof(StateA), invalidTransitionTo, lookup));
+            Assert.Throws<InvalidOperationException>(() => FSMUtils.SetupTransition(typeof(AnyState), invalidTransitionFrom, lookup));
+        }
+
+        [Test]
+        public void VerifyAnyStateActions()
+        {
+            demo.RaiseEvent(new TestEvent());
+            Assert.AreEqual(1, demo.counter);
+            Assert.IsFalse(demo.StateCounter.TryGetValue(typeof(StateA), out int aCount));
+            Assert.IsFalse(demo.StateCounter.TryGetValue(typeof(StateC), out int cCount));
+            Assert.AreEqual(0, cCount);
+            Assert.AreEqual(0, aCount);
+
+            StateMachineTestUtils.SendAndVerifyEventSequence(demo, (new CEvent(), typeof(StateC)));
+            demo.RaiseEvent(new TestEvent());
+            Assert.AreEqual(2, demo.counter);
+            Assert.IsTrue(demo.StateCounter.TryGetValue(typeof(StateC), out cCount));
+            Assert.AreEqual(1, cCount);
+
+            demo.RaiseEvent(new TestEvent());
+            Assert.AreEqual(3, demo.counter);
+            Assert.IsTrue(demo.StateCounter.TryGetValue(typeof(StateC), out cCount));
+            Assert.AreEqual(2, cCount);
+
+            StateMachineTestUtils.SendAndVerifyEventSequence(demo, (new AEvent(), typeof(StateA)));
+            demo.RaiseEvent(new TestEvent());
+            Assert.AreEqual(4, demo.counter);
+            Assert.IsTrue(demo.StateCounter.TryGetValue(typeof(StateC), out cCount));
+            Assert.AreEqual(2, cCount);
+        }
+    }
+}

--- a/Packages/com.nickmaltbie.StateMachineUnity/Tests/EditMode/Fixed/StateMachineAnyStateTests.cs.meta
+++ b/Packages/com.nickmaltbie.StateMachineUnity/Tests/EditMode/Fixed/StateMachineAnyStateTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6e6a20aabdd11ca4883d5e0ff1c4ac80
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.nickmaltbie.StateMachineUnity/Tests/EditMode/Fixed/StateMachineTestUtils.cs
+++ b/Packages/com.nickmaltbie.StateMachineUnity/Tests/EditMode/Fixed/StateMachineTestUtils.cs
@@ -1,0 +1,63 @@
+// Copyright (C) 2022 Nicholas Maltbie
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+// associated documentation files (the "Software"), to deal in the Software without restriction,
+// including without limitation the rights to use, copy, modify, merge, publish, distribute,
+// sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all copies or
+// substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+// BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+// CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+// ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System;
+using System.Collections.Generic;
+using nickmaltbie.StateMachineUnity.Event;
+using NUnit.Framework;
+
+namespace nickmaltbie.StateMachineUnity.Tests.EditMode.Fixed
+{
+    public static class StateMachineTestUtils
+    {
+        /// <summary>
+        /// Send an event sequence to a state machine and verify the given transitions.
+        /// </summary>
+        /// <param name="transitions">Sequence of events and transitions
+        /// to send to the state machine and expect changes.</param>
+        public static void SendAndVerifyEventSequence(IStateMachine<Type> sm, params (IEvent, Type)[] transitions)
+        {
+            SendAndVerifyEventSequence(sm, transitions, true);
+        }
+
+        /// <summary>
+        /// Send an event sequence to a state machine and verify the given transitions.
+        /// </summary>
+        /// <param name="transitions">Sequence of events and transitions
+        /// to send to the state machine and expect changes.</param>
+        public static void SendAndVerifyEventSequence(IStateMachine<Type> sm, IEnumerable<(IEvent, Type)> transitions, bool log = true)
+        {
+            foreach ((IEvent, Type) tuple in transitions)
+            {
+                if (log)
+                {
+                    UnityEngine.Debug.Log($"Sending event {tuple.Item1.GetType()} to state machine");
+                }
+
+                sm.RaiseEvent(tuple.Item1);
+
+                if (log)
+                {
+                    UnityEngine.Debug.Log($"State machine is now in state {sm.CurrentState}");
+                }
+
+                Assert.AreEqual(sm.CurrentState, tuple.Item2);
+            }
+        }
+    }
+}

--- a/Packages/com.nickmaltbie.StateMachineUnity/Tests/EditMode/Fixed/StateMachineTestUtils.cs.meta
+++ b/Packages/com.nickmaltbie.StateMachineUnity/Tests/EditMode/Fixed/StateMachineTestUtils.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8d84e7290a3b33d498dcf7d09fc612c5
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.nickmaltbie.StateMachineUnity/Tests/EditMode/Fixed/StateMachineTests.cs
+++ b/Packages/com.nickmaltbie.StateMachineUnity/Tests/EditMode/Fixed/StateMachineTests.cs
@@ -153,32 +153,7 @@ namespace nickmaltbie.StateMachineUnity.Tests.EditMode.Fixed
         /// to send to the state machine and expect changes.</param>
         public void SendAndVerifyEventSequence(params (IEvent, Type)[] transitions)
         {
-            SendAndVerifyEventSequence(transitions, false);
-        }
-
-        /// <summary>
-        /// Send an event sequence to a state machine and verify the given transitions.
-        /// </summary>
-        /// <param name="transitions">Sequence of events and transitions
-        /// to send to the state machine and expect changes.</param>
-        public void SendAndVerifyEventSequence(IEnumerable<(IEvent, Type)> transitions, bool log = true)
-        {
-            foreach ((IEvent, Type) tuple in transitions)
-            {
-                if (log)
-                {
-                    UnityEngine.Debug.Log($"Sending event {tuple.Item1.GetType()} to state machine");
-                }
-
-                demoStateMachine.RaiseEvent(tuple.Item1);
-
-                if (log)
-                {
-                    UnityEngine.Debug.Log($"State machine is now in state {demoStateMachine.CurrentState}");
-                }
-
-                Assert.AreEqual(demoStateMachine.CurrentState, tuple.Item2);
-            }
+            StateMachineTestUtils.SendAndVerifyEventSequence(demoStateMachine, transitions, false);
         }
     }
 }

--- a/Packages/com.nickmaltbie.StateMachineUnity/Tests/EditMode/Fixed/StateMachineTests.cs
+++ b/Packages/com.nickmaltbie.StateMachineUnity/Tests/EditMode/Fixed/StateMachineTests.cs
@@ -17,7 +17,6 @@
 // SOFTWARE.
 
 using System;
-using System.Collections.Generic;
 using nickmaltbie.StateMachineUnity.Event;
 using nickmaltbie.StateMachineUnity.Tests.EditMode.Event;
 using nickmaltbie.StateMachineUnity.Utils;


### PR DESCRIPTION
# Description

Added `AnyState` support and transitions and `TransitionFromAttribute` in the project.
* Can create a new `State` that inherits from `AnyState`. This state can then be used as a way to add `TransitionAttribute` to transition to a given state from any other state on a given event.
  * This `Anystate` also supports events, on entry, on exit, etc... that are used by any other state for the `FixedSM` and `FixedSMBehaviou` by using adjustments made to the `FSMUtils` class.
* Created a new state called `AnyState` to handle this internally.
* Added a new attribute `TransitionFromAttribute` to allow transition from a target state to the labeled state.
* Added a new attribute `TransitionFromAnyAttribute` to allow to transition from any state to a given state
* Also, cannot transition to `AnyState` or to any state which inherits `AnyState`, this will throw an exception.


# How Has This Been Tested?

Created automated UT to verify that these types of transitions work as expected for all scenarios of transition to, from, etc...
This ensure that the transition map is generated properly for the reverse direction transition (`TransitionFrom`) and for reading any events or transitions for the `AnyState`.

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that demonstrate the new feature or bugfix
- [x] New and existing unit and integrations tests pass locally with my changes
